### PR TITLE
Removes inappropriate dependency from public api.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,14 +139,20 @@
             <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
+        
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.12</version>
+		</dependency>
 
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
-            <version>0.7.1</version>
-            <scope>provided</scope>
-        </dependency>
-
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.3</version>
+			<scope>test</scope>
+		</dependency>
+			
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
We don't need, nor should we need, anything from the dropwizard.io packages for the basic API implementation.  The only thing this was providing was logging, which can be provided independently.  Logback classic is only there for the testing, since that has log output.